### PR TITLE
Modify Cargo.toml directly instead of using `cargo add`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -58,15 +58,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ace50bade8e6234aa140d9a2f552bbee1db4d353f69b8217bc503490fc1a9f26"
 
 [[package]]
-name = "basic-toml"
-version = "0.1.9"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "823388e228f614e9558c6804262db37960ec8821856535f5c3f59913140558f8"
-dependencies = [
- "serde",
-]
-
-[[package]]
 name = "bitflags"
 version = "2.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -76,13 +67,13 @@ checksum = "b048fb63fd8b5923fc5aa7b340d8e156aec7ec02f0c78fa8a6ddc2613f6f71de"
 name = "cargo-interactive-update"
 version = "0.3.1"
 dependencies = [
- "basic-toml",
  "clap",
  "clap-cargo",
  "crossterm",
  "curl",
  "semver",
  "serde_json",
+ "toml_edit",
 ]
 
 [[package]]
@@ -201,6 +192,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "equivalent"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5443807d6dff69373d433ab9ef5378ad8df50ca6298caf15de6e52e24aaf54d5"
+
+[[package]]
 name = "errno"
 version = "0.3.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -209,6 +206,12 @@ dependencies = [
  "libc",
  "windows-sys 0.52.0",
 ]
+
+[[package]]
+name = "hashbrown"
+version = "0.15.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1e087f84d4f86bf4b218b927129862374b72199ae7d8657835f1e89000eea4fb"
 
 [[package]]
 name = "heck"
@@ -221,6 +224,16 @@ name = "hermit-abi"
 version = "0.3.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d231dfb89cfffdbc30e7fc41579ed6066ad03abda9e567ccafae602b97ec5024"
+
+[[package]]
+name = "indexmap"
+version = "2.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "707907fe3c25f5424cce2cb7e1cbcafee6bdbe735ca90ef77c29e84591e5b9da"
+dependencies = [
+ "equivalent",
+ "hashbrown",
+]
 
 [[package]]
 name = "is_terminal_polyfill"
@@ -509,6 +522,23 @@ dependencies = [
 ]
 
 [[package]]
+name = "toml_datetime"
+version = "0.6.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0dd7358ecb8fc2f8d014bf86f6f638ce72ba252a2c3a2572f2a795f1d23efb41"
+
+[[package]]
+name = "toml_edit"
+version = "0.22.22"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4ae48d6208a266e853d946088ed816055e556cc6028c5e8e2b84d9fa5dd7c7f5"
+dependencies = [
+ "indexmap",
+ "toml_datetime",
+ "winnow",
+]
+
+[[package]]
 name = "unicode-ident"
 version = "1.0.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -613,3 +643,12 @@ name = "windows_x86_64_msvc"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "589f6da84c646204747d1270a2a5661ea66ed1cced2631d546fdfb155959f9ec"
+
+[[package]]
+name = "winnow"
+version = "0.6.20"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "36c1fec1a2bb5866f07c25f68c26e565c4c200aebb96d7e55710c19d3e8ac49b"
+dependencies = [
+ "memchr",
+]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,13 +10,13 @@ keywords = ["cargo", "update", "interactive"]
 categories = ["command-line-utilities"]
 
 [dependencies]
-basic-toml = "0.1.9"
 clap = { version = "4.5.20", features = ["derive"] }
 clap-cargo = "0.14.1"
 crossterm = { version = "0.28.1", default-features = false, features = ["events"] }
 curl = "0.4.47"
 semver = "1.0.23"
 serde_json = "1.0.128"
+toml_edit = "0.22.22"
 
 [profile.release]
 lto = true

--- a/README.md
+++ b/README.md
@@ -55,6 +55,7 @@ After selecting the dependencies to update, it will run `cargo add` with the sel
 
 - `-a` or `--all`: Selects all dependencies to be updated
 - `-y` or `--yes`: Execute without asking for confirmation
+- `-n` or `--no-check`: Don't run `cargo check` after updating
 
 For example, if you want to update all dependencies without asking for confirmation, you can run:
 

--- a/src/args.rs
+++ b/src/args.rs
@@ -16,4 +16,8 @@ pub struct Args {
     /// Execute without asking for confirmation
     #[arg(short, long)]
     pub yes: bool,
+
+    /// Don't run `cargo check` after updating
+    #[arg(short, long)]
+    pub no_check: bool,
 }

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -142,7 +142,7 @@ impl State {
                 self.outdated_deps.len().to_string().bold(),
                 self.total_deps.to_string().bold()
             )),
-            MoveToNextLine(2)
+            MoveToNextLine(1)
         )?;
         Ok(())
     }
@@ -183,6 +183,7 @@ impl State {
 
         execute!(
             self.stdout,
+            MoveToNextLine(1),
             PrintStyledContent(format!("{title} ({num_selected} selected):").cyan()),
             MoveToNextLine(1)
         )?;

--- a/src/dependency.rs
+++ b/src/dependency.rs
@@ -51,6 +51,7 @@ impl Dependencies {
     pub fn apply_versions(
         &self,
         mut cargo_toml: DocumentMut,
+        no_check: bool,
     ) -> Result<(), Box<dyn std::error::Error>> {
         if self.0.is_empty() {
             println!("No dependencies have been updated.");
@@ -64,11 +65,12 @@ impl Dependencies {
         }
 
         std::fs::write("Cargo.toml", cargo_toml.to_string())?;
+        println!("Dependencies have been updated in Cargo.toml.");
 
-        println!("Executing {} ...", "cargo check".bold());
-        std::process::Command::new("cargo").arg("check").status()?;
-
-        println!("\nDependencies have been updated.");
+        if !no_check {
+            println!("\nExecuting {}...", "cargo check".bold());
+            std::process::Command::new("cargo").arg("check").status()?;
+        }
 
         Ok(())
     }

--- a/src/main.rs
+++ b/src/main.rs
@@ -25,7 +25,9 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
     let mut state = cli::State::new(outdated_deps, total_deps, args.all);
 
     if args.yes {
-        state.selected_dependencies().apply_versions()?;
+        state
+            .selected_dependencies()
+            .apply_versions(dependencies.cargo_toml)?;
         return Ok(());
     }
 
@@ -37,7 +39,9 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
         match state.handle_keyboard_event()? {
             cli::Event::HandleKeyboard => {}
             cli::Event::UpdateDependencies => {
-                state.selected_dependencies().apply_versions()?;
+                state
+                    .selected_dependencies()
+                    .apply_versions(dependencies.cargo_toml)?;
                 break;
             }
             cli::Event::Exit => {

--- a/src/main.rs
+++ b/src/main.rs
@@ -27,7 +27,7 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
     if args.yes {
         state
             .selected_dependencies()
-            .apply_versions(dependencies.cargo_toml)?;
+            .apply_versions(dependencies.cargo_toml, args.no_check)?;
         return Ok(());
     }
 
@@ -41,7 +41,7 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
             cli::Event::UpdateDependencies => {
                 state
                     .selected_dependencies()
-                    .apply_versions(dependencies.cargo_toml)?;
+                    .apply_versions(dependencies.cargo_toml, args.no_check)?;
                 break;
             }
             cli::Event::Exit => {


### PR DESCRIPTION
- Add no check arg CLI flag to only update the `Cargo.toml` file without updating the lock file or invoking `cargo check/build/...`
- Use `toml_edit` to make changes to the `Cargo.toml` file according to the selected changes

closes #1