### PR TITLE
fix: limit concurrency, display better curl errors, ignore dependencies from `"."` member

### DIFF
--- a/src/api.rs
+++ b/src/api.rs
@@ -88,13 +88,11 @@ pub fn get_latest_version(
 
     {
         let mut transfer = handle.transfer();
-        transfer
-            .write_function(|data| {
-                body.extend_from_slice(data);
-                Ok(data.len())
-            })
-            .unwrap();
-        transfer.perform().unwrap();
+        transfer.write_function(|data| {
+            body.extend_from_slice(data);
+            Ok(data.len())
+        })?;
+        transfer.perform()?;
     }
 
     let response = if body.is_empty() {

--- a/src/cargo.rs
+++ b/src/cargo.rs
@@ -1,5 +1,6 @@
 use cargo_lock::Lockfile;
 use semver::{Version, VersionReq};
+use std::sync::{Arc, Mutex};
 use std::{collections::HashMap, env::current_dir};
 use toml_edit::{DocumentMut, Item, Value};
 
@@ -90,6 +91,7 @@ impl CargoDependencies {
         let mut direct_dependencies_threads = Vec::new();
         let mut workspace_member_threads = Vec::new();
         let mut cargo_toml_files = HashMap::new();
+        let active_requests = Arc::new(Mutex::new(0));
 
         cargo_toml_files.insert(
             workspace_path.clone().unwrap_or_else(|| ".".to_string()),
@@ -99,8 +101,25 @@ impl CargoDependencies {
             let dependency = dependency.clone();
             let package_name = self.package_name.to_string();
             let workspace_path = workspace_path.clone();
+            let active_requests = active_requests.clone();
+
             direct_dependencies_threads.push(std::thread::spawn(move || {
-                dependency.get_latest_version_wrapper(Some(package_name), workspace_path)
+                loop {
+                    let mut count = active_requests.lock().unwrap();
+                    if *count < 5 {
+                        *count += 1;
+                        break;
+                    }
+                    drop(count);
+                    std::thread::sleep(std::time::Duration::from_millis(10));
+                }
+
+                let result =
+                    dependency.get_latest_version_wrapper(Some(package_name), workspace_path);
+
+                *active_requests.lock().unwrap() -= 1;
+
+                result
             }));
         }
 

--- a/src/cargo.rs
+++ b/src/cargo.rs
@@ -328,6 +328,10 @@ fn get_workspace_members(
                 return acc;
             };
 
+            if member == "." {
+                return acc;
+            }
+
             acc.insert(
                 member.to_string(),
                 Box::new(CargoDependencies::gather_dependencies_inner(

--- a/src/cargo.rs
+++ b/src/cargo.rs
@@ -26,12 +26,10 @@ impl CargoDependency {
         let parsed_current_version_req = VersionReq::parse(&self.version).ok()?;
 
         let response = api::get_latest_version(self)
-            .expect(&format!("Unable to reach crates.io for {}", self.name))?;
+            .unwrap_or_else(|_| panic!("Unable to reach crates.io for {}", self.name))?;
 
-        let parsed_latest_version = Version::parse(&response.latest_version).expect(&format!(
-            "Latest version is not a valid semver for {}",
-            self.name
-        ));
+        let parsed_latest_version = Version::parse(&response.latest_version)
+            .unwrap_or_else(|_| panic!("Latest version is not a valid semver for {}", self.name));
 
         if !parsed_current_version_req.matches(&parsed_latest_version) {
             Some(Dependency {

--- a/src/cargo.rs
+++ b/src/cargo.rs
@@ -24,10 +24,13 @@ impl CargoDependency {
     ) -> Option<Dependency> {
         let parsed_current_version_req = VersionReq::parse(&self.version).ok()?;
 
-        let response = api::get_latest_version(self).expect("Unable to reach crates.io")?;
+        let response = api::get_latest_version(self)
+            .expect(&format!("Unable to reach crates.io for {}", self.name))?;
 
-        let parsed_latest_version =
-            Version::parse(&response.latest_version).expect("Latest version is not a valid semver");
+        let parsed_latest_version = Version::parse(&response.latest_version).expect(&format!(
+            "Latest version is not a valid semver for {}",
+            self.name
+        ));
 
         if !parsed_current_version_req.matches(&parsed_latest_version) {
             Some(Dependency {


### PR DESCRIPTION
### Changes

<!-- Specify your changes in bullet points -->

* To remove duplicate dependencies generated from the `"."` workspace member, ignore dependency resolving for `"."`
* Propagate errors from curl
* Make curl errors mention related package name with issue
* Make at most 5 concurrent request per workspace 

### Linked Issues

<!-- Specify the linked GitHub issue if there is one -->

related #17 